### PR TITLE
Allow unicode characters in method names

### DIFF
--- a/src/main/scala/net/kurobako/jmhv/JMHView.scala
+++ b/src/main/scala/net/kurobako/jmhv/JMHView.scala
@@ -250,7 +250,7 @@ object JMHView {
 				case Method    =>
 					Constants(group.groupByMethod(mode, pairWithMetric).toSeq: _*)
 						.mapBinding { case (mtd, xs) =>
-							mkChart(mtd, xs)(_.formatted)
+							mkChart(reflect.NameTransformer.decode(mtd), xs)(_.formatted)
 						}
 			}
 			<div class="result-block">


### PR DESCRIPTION
This PR allows more descriptive method names for benchmarks like this:
``` scala
@Benchmark
def `My benchmark 😀`() = ???
```